### PR TITLE
downgrading sphinx to version 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.10"
 pyyaml = "^6.0"
 m2r2 = "0.3.2"
 watchdog = "^3.0.0"
-sphinx = "^6.2.1"
+sphinx = "^5.3.0"
 sphinx-rtd-theme = "^1.2.0"
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-sphinx_rtd_theme
+sphinx==5.3.0
+sphinx_rtd_theme==1.2.0
 m2r2==0.3.2
-pyyaml
+pyyaml==6.0


### PR DESCRIPTION
Downgrading sphinx to version 5 as version 6 removes jquery which is required for rtd theme